### PR TITLE
Improve device picker cached refresh

### DIFF
--- a/AudioPlaybackConnector2/include/ui/DevicePickerViewModel.hpp
+++ b/AudioPlaybackConnector2/include/ui/DevicePickerViewModel.hpp
@@ -5,6 +5,11 @@
 
 class DeviceManager;
 
+struct CachedDevicePickerDevice {
+    winrt::hstring Id;
+    winrt::hstring Name;
+};
+
 /*------------------------------------------------------------------------------------------------------------*/
 /*//////// Device Picker View Model //////////////////////////////////////////////////////////////////////////*/
 /*------------------------------------------------------------------------------------------------------------*/
@@ -41,5 +46,5 @@ private:
     /*------------------------------------------------------------------------------------------------------------*/
 
     std::weak_ptr<DeviceManager> m_manager;
-    std::vector<winrt::Windows::Devices::Enumeration::DeviceInformation> m_devices;
+    std::vector<CachedDevicePickerDevice> m_devices;
 };

--- a/AudioPlaybackConnector2/src/ui/DevicePickerViewModel.cpp
+++ b/AudioPlaybackConnector2/src/ui/DevicePickerViewModel.cpp
@@ -17,7 +17,15 @@ void DevicePickerViewModel::SetDevices(
     m_devices.clear();
     m_devices.reserve(devices.Size());
     for (auto const& device : devices) {
-        m_devices.push_back(device);
+        auto id = device.Id();
+        auto name = device.Name();
+        if (name.empty()) {
+            name = id;
+        }
+        m_devices.push_back({
+            .Id = id,
+            .Name = name,
+        });
     }
 }
 
@@ -29,12 +37,11 @@ std::vector<DevicePickerItemViewModel> DevicePickerViewModel::SnapshotItems() co
     std::vector<DevicePickerItemViewModel> items;
     items.reserve(m_devices.size());
     for (auto const& device : m_devices) {
-        auto id = device.Id();
         items.push_back({
-            .Id = id,
-            .Name = device.Name(),
-            .IsConnected = IsConnected(id),
-            .IsBusy = IsBusy(id),
+            .Id = device.Id,
+            .Name = device.Name,
+            .IsConnected = IsConnected(device.Id),
+            .IsBusy = IsBusy(device.Id),
         });
     }
     return items;

--- a/AudioPlaybackConnector2/ui/DevicePickerView/DevicePickerView.xaml
+++ b/AudioPlaybackConnector2/ui/DevicePickerView/DevicePickerView.xaml
@@ -21,6 +21,7 @@
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
                 <TextBlock
                     x:Name="TitleText"
@@ -31,9 +32,18 @@
                     FontSize="14"
                     FontWeight="SemiBold"
                     TextTrimming="CharacterEllipsis" />
+                <ProgressRing
+                    x:Name="HeaderRefreshIndicator"
+                    Grid.Column="1"
+                    Width="14"
+                    Height="14"
+                    Margin="0,0,4,0"
+                    VerticalAlignment="Center"
+                    IsActive="False"
+                    Visibility="Collapsed" />
                 <Button
                     x:Name="CloseButton"
-                    Grid.Column="1"
+                    Grid.Column="2"
                     Margin="5"
                     Padding="5"
                     HorizontalAlignment="Right"
@@ -100,7 +110,8 @@
             <ProgressRing
                 x:Name="ProgressIndicator"
                 HorizontalAlignment="Center"
-                IsActive="True" />
+                IsActive="False"
+                Visibility="Collapsed" />
             <ListView
                 x:Name="DeviceList"
                 MaxHeight="480"

--- a/AudioPlaybackConnector2/ui/DevicePickerView/DevicePickerView.xaml.cpp
+++ b/AudioPlaybackConnector2/ui/DevicePickerView/DevicePickerView.xaml.cpp
@@ -143,22 +143,27 @@ void DevicePickerView::Initialize(std::shared_ptr<DeviceManager> manager,
 }
 
 void DevicePickerView::LoadDevices() {
-    if (m_isLoadingDevices) return;
+    if (!m_viewModel.Empty()) {
+        RebuildDeviceListFromCache();
+    }
+
+    if (m_isLoadingDevices) {
+        SetRefreshIndicators(true, m_viewModel.Empty());
+        return;
+    }
 
     m_isLoadingDevices.store(true);
     m_loadDevicesCancelled.store(false);
     auto requestId = ++m_loadDevicesRequestId;
     m_activeLoadRequestId.store(requestId);
 
-    bool listWasEmpty = DeviceList().Items().Size() == 0;
-    if (listWasEmpty) {
-        ProgressIndicator().Visibility(Visibility::Visible);
-        ProgressIndicator().IsActive(true);
-    }
+    const bool blockingRefresh = m_viewModel.Empty() && DeviceList().Items().Size() == 0;
+    SetRefreshIndicators(true, blockingRefresh);
 
     auto dispatcher = this->DispatcherQueue();
     if (!dispatcher) {
         DebugTrace(L"[DevicePickerView] ERROR: no UI dispatcher available for LoadDevices");
+        SetRefreshIndicators(false, false);
         m_isLoadingDevices.store(false);
         m_activeLoadRequestId.store(0);
         return;
@@ -167,7 +172,7 @@ void DevicePickerView::LoadDevices() {
     auto manager = m_deviceManager.lock();
     if (!manager) {
         DebugTrace(L"[DevicePickerView] ERROR: no DeviceManager available for LoadDevices");
-        OnDeviceEnumerationFailed(listWasEmpty, requestId);
+        OnDeviceEnumerationFailed(blockingRefresh, requestId);
         return;
     }
 
@@ -190,8 +195,8 @@ void DevicePickerView::LoadDevices() {
     winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Devices::Enumeration::DeviceInformationCollection>
         pendingOp = refreshOp;
 
-    pendingOp.Completed([weak, dispatcher, listWasEmpty, requestId](auto const& sender,
-                                                                    winrt::Windows::Foundation::AsyncStatus status) {
+    pendingOp.Completed([weak, dispatcher, blockingRefresh, requestId](auto const& sender,
+                                                                       winrt::Windows::Foundation::AsyncStatus status) {
         if (auto self = weak.get()) {
             std::lock_guard lock(self->m_refreshDevicesOpMutex);
             if (self->m_activeLoadRequestId.load() != requestId) {
@@ -210,8 +215,8 @@ void DevicePickerView::LoadDevices() {
             return;
         }
         auto enqueueFailure = [&]() {
-            bool enqueued = dispatcher.TryEnqueue([weak, listWasEmpty, requestId]() {
-                if (auto self = weak.get()) self->OnDeviceEnumerationFailed(listWasEmpty, requestId);
+            bool enqueued = dispatcher.TryEnqueue([weak, blockingRefresh, requestId]() {
+                if (auto self = weak.get()) self->OnDeviceEnumerationFailed(blockingRefresh, requestId);
             });
             if (!enqueued) {
                 DebugTrace(L"[DevicePickerView] ERROR: failed to marshal OnDeviceEnumerationFailed to UI thread");
@@ -226,8 +231,8 @@ void DevicePickerView::LoadDevices() {
         };
         try {
             auto devices = sender.GetResults();
-            bool enqueued = dispatcher.TryEnqueue([weak, devices, listWasEmpty, requestId]() {
-                if (auto self = weak.get()) self->ApplyDeviceResults(devices, listWasEmpty, requestId);
+            bool enqueued = dispatcher.TryEnqueue([weak, devices, blockingRefresh, requestId]() {
+                if (auto self = weak.get()) self->ApplyDeviceResults(devices, blockingRefresh, requestId);
             });
             if (!enqueued) {
                 DebugTrace(L"[DevicePickerView] ERROR: failed to marshal ApplyDeviceResults to UI thread");
@@ -259,6 +264,7 @@ void DevicePickerView::CancelLoadDevices() {
     auto invalidatedRequest = ++m_loadDevicesRequestId;
     m_activeLoadRequestId.store(invalidatedRequest);
     m_isLoadingDevices.store(false);
+    SetRefreshIndicators(false, false);
     winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Devices::Enumeration::DeviceInformationCollection> op{
         nullptr};
     {
@@ -269,9 +275,7 @@ void DevicePickerView::CancelLoadDevices() {
 }
 
 void DevicePickerView::RefreshDeviceStates() {
-    if (m_isLoadingDevices.load()) {
-        return;
-    }
+    if (m_viewModel.Empty()) return;
     RebuildDeviceListFromCache();
 }
 
@@ -281,23 +285,22 @@ void DevicePickerView::RefreshDeviceStates() {
 
 void DevicePickerView::ApplyDeviceResults(
     winrt::Windows::Devices::Enumeration::DeviceInformationCollection const& devices,
-    bool listWasEmpty,
+    bool blockingRefresh,
     uint64_t requestId) {
     if (m_loadDevicesRequestId.load() != requestId) return;
     if (m_activeLoadRequestId.load() != requestId) return;
     if (m_loadDevicesCancelled) {
-        if (listWasEmpty) {
-            ProgressIndicator().IsActive(false);
-            ProgressIndicator().Visibility(Visibility::Collapsed);
-        }
+        SetRefreshIndicators(false, false);
         m_isLoadingDevices.store(false);
         m_activeLoadRequestId.store(0);
         return;
     }
-    ProgressIndicator().IsActive(false);
-    ProgressIndicator().Visibility(Visibility::Collapsed);
+    SetRefreshIndicators(false, false);
 
     if (!devices) {
+        if (blockingRefresh && m_viewModel.Empty() && DeviceList().Items().Size() == 0) {
+            RebuildDeviceListFromCache();
+        }
         m_isLoadingDevices.store(false);
         m_activeLoadRequestId.store(0);
         return;
@@ -309,16 +312,16 @@ void DevicePickerView::ApplyDeviceResults(
     m_activeLoadRequestId.store(0);
 }
 
-void DevicePickerView::OnDeviceEnumerationFailed(bool listWasEmpty, uint64_t requestId) {
+void DevicePickerView::OnDeviceEnumerationFailed(bool blockingRefresh, uint64_t requestId) {
     if (m_loadDevicesRequestId.load() != requestId) return;
     if (m_activeLoadRequestId.load() != requestId) return;
     if (m_loadDevicesCancelled.load()) return;
-    if (listWasEmpty) {
-        ProgressIndicator().IsActive(false);
-        ProgressIndicator().Visibility(Visibility::Collapsed);
-    }
+    SetRefreshIndicators(false, false);
     m_isLoadingDevices.store(false);
     m_activeLoadRequestId.store(0);
+    if (blockingRefresh && m_viewModel.Empty() && DeviceList().Items().Size() == 0) {
+        RebuildDeviceListFromCache();
+    }
 }
 
 void DevicePickerView::RebuildDeviceListFromCache(bool reconcilePendingActions) {
@@ -478,6 +481,13 @@ void DevicePickerView::ApplyGlobalActionState(bool visible, bool enabled) {
     GlobalActionsPanel().Visibility(visible ? Visibility::Visible : Visibility::Collapsed);
     DisconnectAllButton().IsEnabled(visible && enabled);
     ReconnectAllButton().IsEnabled(visible && enabled);
+}
+
+void DevicePickerView::SetRefreshIndicators(bool refreshing, bool blockingRefresh) {
+    HeaderRefreshIndicator().IsActive(refreshing && !blockingRefresh);
+    HeaderRefreshIndicator().Visibility(refreshing && !blockingRefresh ? Visibility::Visible : Visibility::Collapsed);
+    ProgressIndicator().IsActive(refreshing && blockingRefresh);
+    ProgressIndicator().Visibility(refreshing && blockingRefresh ? Visibility::Visible : Visibility::Collapsed);
 }
 
 /*------------------------------------------------------------------------------------------------------------*/

--- a/AudioPlaybackConnector2/ui/DevicePickerView/DevicePickerView.xaml.h
+++ b/AudioPlaybackConnector2/ui/DevicePickerView/DevicePickerView.xaml.h
@@ -47,9 +47,9 @@ private:
     void OnDeviceReconnectClicked(winrt::hstring const& id);
 
     void ApplyDeviceResults(winrt::Windows::Devices::Enumeration::DeviceInformationCollection const& devices,
-                            bool listWasEmpty,
+                            bool blockingRefresh,
                             uint64_t requestId);
-    void OnDeviceEnumerationFailed(bool listWasEmpty, uint64_t requestId);
+    void OnDeviceEnumerationFailed(bool blockingRefresh, uint64_t requestId);
     void RebuildDeviceListFromCache(bool reconcilePendingActions = true);
     winrt::Microsoft::UI::Xaml::Controls::ListViewItem BuildDeviceListItem(DevicePickerItemViewModel const& device);
     bool BeginPendingDeviceAction(winrt::hstring const& id);
@@ -57,6 +57,7 @@ private:
     bool IsDeviceActionPending(winrt::hstring const& id) const;
     void ReconcilePendingActions(std::vector<DevicePickerItemViewModel> const& items);
     void ApplyGlobalActionState(bool visible, bool enabled);
+    void SetRefreshIndicators(bool refreshing, bool blockingRefresh);
 
     DevicePickerViewModel m_viewModel;
     std::function<void()> m_onClose;


### PR DESCRIPTION
## Summary

- Show cached device picker entries immediately before kicking off a fresh device enumeration.
- Add a small header refresh indicator for background refreshes while keeping the existing blocking spinner for first load.
- Cache plain device IDs/names in the picker view model instead of retaining `DeviceInformation` objects for later UI rebuilds.

## Validation

- Rebased onto current `origin/develop` after command-line support landed.
- `msbuild AudioPlaybackConnector2\\AudioPlaybackConnector2.vcxproj /p:Configuration=Debug /p:Platform=x64 /p:PreferredToolArchitecture=x64`
- `clang-format --dry-run --Werror AudioPlaybackConnector2/include/ui/DevicePickerViewModel.hpp AudioPlaybackConnector2/src/ui/DevicePickerViewModel.cpp AudioPlaybackConnector2/ui/DevicePickerView/DevicePickerView.xaml.cpp AudioPlaybackConnector2/ui/DevicePickerView/DevicePickerView.xaml.h`
- `cppcheck --enable=warning,performance,portability --std=c++20 --platform=win64 AudioPlaybackConnector2/src/`
- Runtime smoke test from the packaged AppX debug output: app initialized, tray picker opened/closed, device selection triggered connect, and `OpenAsync` returned `Success`.

## Notes

The GitHub build workflow currently runs only for PRs targeting `main`, so PRs targeting `develop` report no GitHub checks. Local build/static checks were run after rebasing onto `develop`.