### PR TITLE
Fix tray icon state when connected

### DIFF
--- a/AudioPlaybackConnector2/src/app/ApplicationHost.cpp
+++ b/AudioPlaybackConnector2/src/app/ApplicationHost.cpp
@@ -554,15 +554,18 @@ void ApplicationHost::RefreshTrayVisualState(bool forceErrorWhenIdle) {
     const bool hasBusyOperations = m_deviceManager->HasBusyOperations();
     const bool hasConnections = m_deviceManager->HasConnections();
 
-    if (forceErrorWhenIdle) {
+    if (hasConnections) {
         KillTimer(m_hwnd, c_timerAnimation);
-        m_trayController->SetState(hasConnections ? TrayIconState::Connected : TrayIconState::Error);
+        m_trayController->SetState(TrayIconState::Connected);
+    } else if (forceErrorWhenIdle) {
+        KillTimer(m_hwnd, c_timerAnimation);
+        m_trayController->SetState(TrayIconState::Error);
     } else if (hasBusyOperations) {
         m_trayController->SetState(TrayIconState::Connecting);
         SetTimer(m_hwnd, c_timerAnimation, 75, nullptr);
     } else {
         KillTimer(m_hwnd, c_timerAnimation);
-        m_trayController->SetState(hasConnections ? TrayIconState::Connected : TrayIconState::Idle);
+        m_trayController->SetState(TrayIconState::Idle);
     }
 
     if (!forceErrorWhenIdle) {


### PR DESCRIPTION
## Summary

- Keep the tray icon in the connected state whenever at least one playback connection is open.
- Only show the connecting animation when there are busy operations and no active connection.

## Root cause

`RefreshTrayVisualState()` prioritized busy operations over existing connections. If a reconnect or pending operation existed while another device was already connected, the tray icon could remain in a non-green state even though the device picker showed a connected device.

Fixes #10.

## Validation

- `clang-format --dry-run --Werror` on source/header files
- `cppcheck --enable=warning,performance,portability --std=c++20 --platform=win64 AudioPlaybackConnector2/src/`
- `msbuild AudioPlaybackConnector2/AudioPlaybackConnector2.vcxproj /p:Configuration=Debug /p:Platform=x64 /p:PreferredToolArchitecture=x64`