### PR TITLE
Prepare 0.6.1 release

### DIFF
--- a/AudioPlaybackConnector2 (Package)/Package.appxmanifest
+++ b/AudioPlaybackConnector2 (Package)/Package.appxmanifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10" IgnorableNamespaces="uap uap3 rescap desktop com">
-  <Identity Name="N0ahTM.AudioPlaybackConnector2" Publisher="CN=AudioPlaybackConnector2" Version="0.6.0.0" />
+  <Identity Name="N0ahTM.AudioPlaybackConnector2" Publisher="CN=AudioPlaybackConnector2" Version="0.6.1.0" />
   <Properties>
     <DisplayName>AudioPlaybackConnector2</DisplayName>
     <PublisherDisplayName>Noah Meyer</PublisherDisplayName>

--- a/AudioPlaybackConnector2/res/AudioPlaybackConnector2.rc
+++ b/AudioPlaybackConnector2/res/AudioPlaybackConnector2.rc
@@ -8,8 +8,8 @@
 LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 0,6,0,0
- PRODUCTVERSION 0,6,0,0
+ FILEVERSION 0,6,1,0
+ PRODUCTVERSION 0,6,1,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -26,12 +26,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Noah Meyer"
             VALUE "FileDescription", "AudioPlaybackConnector2"
-            VALUE "FileVersion", "0.6.0.0"
+            VALUE "FileVersion", "0.6.1.0"
             VALUE "InternalName", "AudioPlaybackConnector2.exe"
             VALUE "LegalCopyright", "Copyright (C) 2026 Noah Meyer"
             VALUE "OriginalFilename", "AudioPlaybackConnector2.exe"
             VALUE "ProductName", "AudioPlaybackConnector2"
-            VALUE "ProductVersion", "0.6.0.0"
+            VALUE "ProductVersion", "0.6.1.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-06-20
+
 ### Added
 - Added `apc2ctl.exe` command line control for listing devices, status checks, connect/disconnect/reconnect actions, last-device toggle, and macro-friendly ID/name/MAC targeting (`#7`).
+
+### Fixed
+- Fixed the tray icon staying in a non-connected color while a playback connection is already open (`#10`).
 
 ## [0.6.0] - 2026-06-17
 

--- a/scripts/release/prepare-local-release.ps1
+++ b/scripts/release/prepare-local-release.ps1
@@ -1,9 +1,9 @@
-# Builds a local Release x64 MSIX (unsigned) and copies release assets into ./dist/v0.6.0/
-# For signed GitHub releases, push tag v0.6.0 and use the Release workflow instead.
+# Builds a local Release x64 MSIX (unsigned) and copies release assets into ./dist/v0.6.1/
+# For signed GitHub releases, push tag v0.6.1 and use the Release workflow instead.
 
 param(
-    [string]$Version = "0.6.0.0",
-    [string]$SemVer = "0.6.0",
+    [string]$Version = "0.6.1.0",
+    [string]$SemVer = "0.6.1",
     [string]$Architecture = "x64",
     [string]$Configuration = "Release"
 )


### PR DESCRIPTION
## Summary

- Bump package and executable metadata to `0.6.1.0`.
- Move completed `0.6.1` work from `Unreleased` into a dated changelog section.
- Update the local release helper defaults to build `v0.6.1` bundles.

## Backlog notes

- `#7` is already completed and included in the `0.6.1` changelog.
- `#10` is fixed in `develop` via `#11` and now listed under `0.6.1` fixes.

## Validation

- `git diff --check`
- `msbuild AudioPlaybackConnector2.slnx /p:Configuration=Debug /p:Platform=x64`